### PR TITLE
Connolly School of the Holy Child

### DIFF
--- a/lib/domains/org/holychild.txt
+++ b/lib/domains/org/holychild.txt
@@ -1,0 +1,1 @@
+Connelly School of the Holy Child


### PR DESCRIPTION
Connolly School of the Holy Child
https://www.holychild.org/
Catholic High School in Potomac, MD